### PR TITLE
Add support for parent/child SAMPLING_PRIORITY

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -4,7 +4,7 @@ import { SpanContext } from './span-context';
 import { HoneyOptions } from 'libhoney';
 
 export type TracerOptions = HoneyOptions | Libhoney;
-export type SpanTags = { [key: string]: string };
+export type SpanTags = { [key: string]: any };
 
 export interface SpanOptions {
   childOf?: SpanContext | Span;

--- a/src/span-context.ts
+++ b/src/span-context.ts
@@ -1,12 +1,22 @@
+import { SpanTags } from './shared';
+
 export class SpanContext {
-  constructor(private traceId: string, private spanId: string) {
+  constructor(
+    private traceId: string,
+    private spanId: string,
+    private tags: SpanTags,
+  ) {
     this.traceId = traceId;
     this.spanId = spanId;
+    this.tags = tags;
   }
   toSpanId() {
     return this.spanId;
   }
   toTraceId() {
     return this.traceId;
+  }
+  getTag(key: string) {
+    return this.tags[key];
   }
 }

--- a/src/span.ts
+++ b/src/span.ts
@@ -9,10 +9,9 @@ export class Span {
   private name: string;
   private traceId: string;
   private parentId: string | undefined;
-  private tags: SpanTags = {};
+  private tags: SpanTags;
   private spanId: string;
   private start: Date;
-  private ctx: SpanContext;
 
   constructor(
     event: HoneyEvent,
@@ -30,12 +29,11 @@ export class Span {
     this.spanId = spanId;
     this.parentId = parentId;
     this.tags = tags || {};
-    this.ctx = new SpanContext(traceId, spanId);
     this.start = new Date();
   }
 
   context() {
-    return this.ctx;
+    return new SpanContext(this.traceId, this.spanId, this.tags);
   }
 
   addTags(tags: SpanTags) {

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,6 +1,7 @@
 import { TracerOptions, SpanOptions } from './shared';
 import { Span } from './span';
 import { SpanContext } from './span-context';
+import { SAMPLING_PRIORITY } from './tags';
 import Libhoney from 'libhoney';
 
 export class Tracer {
@@ -16,18 +17,29 @@ export class Tracer {
     }
   }
   startSpan(name: string, spanOptions: SpanOptions = {}) {
-    const { childOf, tags } = spanOptions;
+    const { childOf, tags={} } = spanOptions;
     let traceId: string | undefined;
     let parentId: string | undefined;
+    let samplingPriority: number | undefined;
+
     if (childOf instanceof Span) {
-      traceId = childOf.context().toTraceId();
-      parentId = childOf.context().toSpanId();
+      const ctx = childOf.context();
+      traceId = ctx.toTraceId();
+      parentId = ctx.toSpanId();
+      samplingPriority = ctx.getTag(SAMPLING_PRIORITY);
     } else if (childOf instanceof SpanContext) {
       traceId = childOf.toTraceId();
       parentId = childOf.toSpanId();
+      samplingPriority = childOf.getTag(SAMPLING_PRIORITY);
     } else if (childOf) {
       throw new Error('Expected `childOf` to be Span or SpanContext');
     }
+
+    // If the parent has a sampling priority, copy value to the child
+    if (typeof samplingPriority !== 'undefined') {
+      tags[SAMPLING_PRIORITY] = samplingPriority;
+    }
+
     return new Span(
       this.hny.newEvent(),
       this.serviceName,

--- a/test/tracer.test.ts
+++ b/test/tracer.test.ts
@@ -1,6 +1,7 @@
 import test from 'tape';
 import { Tracer } from '../src/tracer';
 import Libhoney, { HoneyEvent, HoneyOptions } from 'libhoney';
+import {SAMPLING_PRIORITY} from '../src/tags';
 
 function newDummyHoney(addField?: (key: string, value: any) => void) {
   const noop = () => {};
@@ -42,6 +43,18 @@ test('test tracer traceId is same for parent & child', t => {
   const parentSpan = tracer.startSpan('parent');
   const childSpan = tracer.startSpan('child', { childOf: parentSpan });
   t.equal(parentSpan.context().toTraceId(), childSpan.context().toTraceId());
+});
+
+test('test tracer sample priority is same for parent & child', t => {
+  t.plan(2);
+  const tracer = new Tracer('service name', newDummyHoney());
+  const tags = { [SAMPLING_PRIORITY]: 75 };
+  const parentSpan = tracer.startSpan('parent', {tags});
+  const childSpan = tracer.startSpan('child', { childOf: parentSpan });
+  const parentPriority = parentSpan.context().getTag(SAMPLING_PRIORITY);
+  const childPriority = childSpan.context().getTag(SAMPLING_PRIORITY);
+  t.equal(parentPriority, 75);
+  t.equal(childPriority, 75);
 });
 
 test('test tracer tags', t => {


### PR DESCRIPTION
We don't really want people to be dealing with passing around `SAMPLING_PRIORITY` because it will typically get set from `req.headers` on the top-level span and then all other child spans should get this value.

Fixes #1 

/cc @hharnisc 