### PR TITLE
Prevent sending more than once, allow multiple calls to span.finish()

### DIFF
--- a/src/span.ts
+++ b/src/span.ts
@@ -14,6 +14,7 @@ export class Span {
   private parentId: string | undefined;
   private tags: SpanTags;
   private start: Date;
+  private duration: number | undefined;
 
   constructor(
     event: HoneyEvent,
@@ -69,7 +70,10 @@ export class Span {
   }
 
   finish() {
-    const duration = Date.now() - this.start.getTime();
+    if (typeof this.duration !== 'undefined') {
+      return;
+    }
+    this.duration = Date.now() - this.start.getTime();
     const {
       serviceName,
       environment,
@@ -83,7 +87,7 @@ export class Span {
       return;
     }
 
-    this.event.addField('duration_ms', duration);
+    this.event.addField('duration_ms', this.duration);
     this.event.addField('name', this.name);
     this.event.addField('service_name', serviceName);
     this.event.addField('environment', environment);

--- a/test/span.test.ts
+++ b/test/span.test.ts
@@ -123,16 +123,14 @@ test('test span addField', t => {
 });
 
 test('test span addField should favor priority over sampler', t => {
-  t.plan(2);
+  t.plan(1);
   const options = getTracerOptions(new DeterministicSampler(20));
   const name = 'function name';
   const traceId = 'trace123';
   const parentId = 'parent123';
   const tags = { [SAMPLING_PRIORITY]: 1 };
   const event: HoneyEvent = {
-    send: () => {
-      t.true(event.timestamp && event.timestamp > new Date(0));
-    },
+    send: noop,
     addField: (key: string, value: any) => {
       switch (key) {
         case 'samplerate':
@@ -143,6 +141,25 @@ test('test span addField should favor priority over sampler', t => {
   };
   const span = new Span(event, options, name, traceId, parentId, tags);
   setTimeout(() => span.finish(), 50);
+});
+
+
+test('test span finish should call send at most once', t => {
+  t.plan(1);
+  const options = getTracerOptions(new DeterministicSampler(20));
+  const name = 'function name';
+  const traceId = 'trace123';
+  const parentId = 'parent123';
+  const tags = { [SAMPLING_PRIORITY]: 1 };
+  const event: HoneyEvent = {
+    send: () => {
+      t.true(true, 'should be called exactly once');
+    },
+    addField: noop
+  };
+  const span = new Span(event, options, name, traceId, parentId, tags);
+  span.finish();
+  span.finish();
 });
 
 test('test span sample rate 0 should not send', t => {


### PR DESCRIPTION
Fixes #16

There are scenarios where the user might call `span.finish()` twice (think of a try/catch) and send the same trace data twice. This would screw up the duration.

We should prevent this behavior and instead make `span.finish()` indepotent - at most, one call.